### PR TITLE
feat: Implement AI Copilot with tool-using agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+venv/
 build/
 develop-eggs/
 dist/

--- a/algorithms/paper2code/env.sample
+++ b/algorithms/paper2code/env.sample
@@ -9,6 +9,11 @@ ANTHROPIC_API_KEY=your_anthropic_api_key_here
 # Default LLM Provider
 DEFAULT_LLM_PROVIDER=gemini
 
+# LLM Model Names (optional, defaults are provided)
+GEMINI_MODEL=gemini-1.5-flash
+OPENAI_MODEL=gpt-4o
+ANTHROPIC_MODEL=claude-3-haiku-20240307
+
 # Application Settings
 DEFAULT_OUTPUT_DIR=./output
 DEFAULT_ANALYSIS_DEPTH=detailed

--- a/app.py
+++ b/app.py
@@ -7,16 +7,28 @@ from ui.ui_paperqa import create_paperqa_tab
 from ui.ui_mindmap import create_mindmap_tab
 from ui.ui_library import create_library_tab
 from ui.custom_css import CUSTOM_CSS
+from core.article_manager import ArticleManager
+from core.collections_manager import CollectionsManager
+from core.copilot_service import CopilotService
+from core.llm_service import LLMService
+
 
 def main():
     with gr.Blocks(css=CUSTOM_CSS) as demo:
         gr.Markdown("# PaperAnt X")
         state = get_shared_state()
+
+        # Instantiate core services
+        llm_service = LLMService()
+        collections_manager = CollectionsManager()
+        article_manager = ArticleManager(collections_manager)
+        copilot_service = CopilotService(collections_manager, article_manager, llm_service)
+
         with gr.Tabs():
             create_articles_tab(state)
             create_paperqa_tab(state)
             create_mindmap_tab(state)
-            create_copilot_tab(state)
+            create_copilot_tab(state, copilot_service)
             create_collections_tab(state)
             create_library_tab(state)
     demo.launch()

--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ from core.article_manager import ArticleManager
 from core.collections_manager import CollectionsManager
 from core.copilot_service import CopilotService
 from core.llm_service import LLMService
+from core.mcp_server_manager import MCPServerManager
 
 
 def main():
@@ -18,11 +19,11 @@ def main():
         gr.Markdown("# PaperAnt X")
         state = get_shared_state()
 
-        # Instantiate core services
         llm_service = LLMService()
         collections_manager = CollectionsManager()
         article_manager = ArticleManager(collections_manager)
-        copilot_service = CopilotService(collections_manager, article_manager, llm_service)
+        mcp_server_manager = MCPServerManager()
+        copilot_service = CopilotService(collections_manager, article_manager, llm_service, mcp_server_manager)
 
         with gr.Tabs():
             create_articles_tab(state)

--- a/core/copilot_agents/__init__.py
+++ b/core/copilot_agents/__init__.py
@@ -1,0 +1,1 @@
+# This file makes the 'copilot_agents' directory a Python package.

--- a/core/copilot_agents/calculator_assistant.json
+++ b/core/copilot_agents/calculator_assistant.json
@@ -1,0 +1,24 @@
+{
+  "name": "Calculator Assistant",
+  "description": "An assistant that can perform calculations using a tool.",
+  "model_prompt": "You are a helpful assistant with access to a calculator. Use the calculator tool to answer mathematical questions.",
+  "mcp_info": {
+    "server_id": "managed_calculator",
+    "tools": [
+      {
+        "name": "calculate",
+        "description": "Performs a mathematical calculation. The input should be a single string representing a valid mathematical expression (e.g., '2 + 2', '10 * (4 - 2)', 'sqrt(16)').",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "expression": {
+              "type": "string",
+              "description": "The mathematical expression to evaluate."
+            }
+          },
+          "required": ["expression"]
+        }
+      }
+    ]
+  }
+}

--- a/core/copilot_agents/csv_assistant.json
+++ b/core/copilot_agents/csv_assistant.json
@@ -1,0 +1,67 @@
+{
+  "name": "CSV Assistant",
+  "description": "An assistant that can load and query data from CSV files on the local filesystem.",
+  "model_prompt": "You are a helpful assistant with access to tools for reading and analyzing CSV files. When asked about a file, first use the `load_csv` tool with the provided file path. Then use the other available tools to answer questions about the data. Always check the headers and summary first to understand the data structure before attempting to query it.",
+  "mcp_info": {
+    "server_id": "managed_csv",
+    "tools": [
+      {
+        "name": "load_csv",
+        "description": "Loads a CSV file from the local filesystem into memory for querying. Expands user home directory `~`.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "file_path": {
+              "type": "string",
+              "description": "The local path to the CSV file (e.g., '~/Downloads/data.csv')."
+            }
+          },
+          "required": ["file_path"]
+        }
+      },
+      {
+        "name": "get_csv_headers",
+        "description": "Returns the column headers of the currently loaded CSV file as a comma-separated string.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "show_head",
+        "description": "Displays the first few rows of the loaded CSV file.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "rows": {
+              "type": "integer",
+              "description": "The number of rows to display from the top of the file. Defaults to 5."
+            }
+          }
+        }
+      },
+      {
+        "name": "get_summary",
+        "description": "Provides a summary of the loaded CSV file, including column data types, non-null counts, and descriptive statistics for numerical columns.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {}
+        }
+      },
+      {
+        "name": "query_data",
+        "description": "Queries the loaded CSV data using a pandas query expression. Example: 'Age > 30', '`Country` == \"USA\" and `Salary` > 50000'. Column names with spaces or special characters should be enclosed in backticks ``.",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "query_expression": {
+              "type": "string",
+              "description": "A string containing the pandas query expression."
+            }
+          },
+          "required": ["query_expression"]
+        }
+      }
+    ]
+  }
+}

--- a/core/copilot_agents/general_assistant.json
+++ b/core/copilot_agents/general_assistant.json
@@ -1,0 +1,6 @@
+{
+  "name": "General Assistant",
+  "description": "Basic LLM chat (no tools)",
+  "model_prompt": null,
+  "mcp_info": null
+}

--- a/core/copilot_service.py
+++ b/core/copilot_service.py
@@ -85,7 +85,7 @@ class CopilotService:
                 print(f"Error while stopping MCP sessions after failure: {stop_e}")
             return json.dumps({"error": error_message})
 
-    def chat_with_agent(self, agent_name: str, message: str, llm_history: List[Dict[str, Any]]) -> Generator[Dict, None, None]:
+    def chat_with_agent(self, agent_name: str, message: str, llm_history: List[Dict[str, Any]], provider: str, model: str) -> Generator[Dict, None, None]:
         """
         Handles a chat interaction with a specific agent, supporting tools.
         This is a generator function to support streaming and tool calls.
@@ -99,7 +99,6 @@ class CopilotService:
         mcp_info = agent_config.get('mcp_info', None)
         tools = mcp_info.get('tools', []) if mcp_info else []
         server_id = mcp_info.get('server_id') if mcp_info else None
-        provider = os.getenv("DEFAULT_LLM_PROVIDER", "gemini")
 
         # Add the new user message to the conversation history.
         messages: List[Dict[str, Any]] = llm_history + [{"role": "user", "content": message}]
@@ -110,6 +109,7 @@ class CopilotService:
                 messages=messages,
                 system_prompt=system_prompt,
                 provider=provider,
+                model=model,
                 tools=tools
             )
 

--- a/core/copilot_service.py
+++ b/core/copilot_service.py
@@ -1,19 +1,21 @@
-# Placeholder for AI copilot/LLM integration logic
 import json
 import os
-from typing import Dict, List, Optional, Any, Tuple
+import subprocess
+from typing import Dict, List, Optional, Any, Tuple, Generator
 
 from .data_models import Article, Collection
 from .collections_manager import CollectionsManager
 from .article_manager import ArticleManager
 from .llm_service import LLMService
+from .mcp_server_manager import MCPServerManager
 
 class CopilotService:
-    def __init__(self, collections_manager: CollectionsManager, article_manager: ArticleManager, llm_service: LLMService) -> None:
+    def __init__(self, collections_manager: CollectionsManager, article_manager: ArticleManager, llm_service: LLMService, mcp_server_manager: MCPServerManager) -> None:
         """Initialize CopilotService with references to the managers"""
         self.collections_manager = collections_manager
         self.article_manager = article_manager
         self.llm_service = llm_service
+        self.mcp_server_manager = mcp_server_manager
         self.agents: Dict[str, Any] = self._load_agents()
 
     def reload(self) -> List[str]:
@@ -50,34 +52,138 @@ class CopilotService:
         """Returns the configuration for a specific agent."""
         return self.agents.get(agent_name)
 
-    def chat_with_agent(self, agent_name: str, message: str, chat_history: List[List[str]]):
+    def _execute_mcp_tool(self, server_id: str, tool_name: str, arguments: Dict[str, Any]) -> str:
         """
-        Handles a chat interaction with a specific agent using the LLMService.
-        This is now a generator function to support streaming.
+        Executes a tool on a managed MCP server by establishing a persistent session.
+        This delegates the async execution to the MCPServerManager.
+        """
+        async def call_tool_async():
+            session = await self.mcp_server_manager.get_session(server_id)
+            if not session:
+                raise ConnectionError(f"Could not establish session with MCP server '{server_id}'.")
+
+            # The mcp-python client library is expected to raise an exception if the tool
+            # call results in an error. This simplifies error handling.
+            response = await session.call_tool(name=tool_name, arguments=arguments)
+
+            # If no exception is raised, the tool execution was successful.
+            return " ".join([part.text for part in response.content if hasattr(part, 'text')]).strip()
+
+        try:
+            print(f"Executing tool '{tool_name}' on server '{server_id}'...")
+            # The MCPServerManager handles running the coroutine in its own event loop.
+            result = self.mcp_server_manager.run_coroutine_and_get_result(call_tool_async())
+            print(f"Tool '{tool_name}' executed successfully. Result: {result}")
+            return result
+        except Exception as e:
+            error_message = f"Error executing tool '{tool_name}' on server '{server_id}': {e}"
+            print(error_message)
+            # On failure, try to gracefully shut down sessions to ensure a clean state.
+            try:
+                self.mcp_server_manager.run_coroutine_and_get_result(self.mcp_server_manager.stop_all_async())
+            except Exception as stop_e:
+                print(f"Error while stopping MCP sessions after failure: {stop_e}")
+            return json.dumps({"error": error_message})
+
+    def chat_with_agent(self, agent_name: str, message: str, llm_history: List[Dict[str, Any]]) -> Generator[Dict, None, None]:
+        """
+        Handles a chat interaction with a specific agent, supporting tools.
+        This is a generator function to support streaming and tool calls.
         """
         agent_config = self.get_agent_details(agent_name)
         if not agent_config:
-            yield "Error: Agent not found."
+            yield {"type": "error", "content": "Agent not found."}
             return
 
         system_prompt = agent_config.get('model_prompt', None)
-        
-        # Convert Gradio history to LLM-compatible format
-        messages = []
-        for user_msg, assistant_msg in chat_history:
-            if user_msg:
-                messages.append({"role": "user", "content": user_msg})
-            if assistant_msg:
-                messages.append({"role": "assistant", "content": assistant_msg})
-        messages.append({"role": "user", "content": message})
-
-        # Get default provider from env, but can be overridden by agent config later
+        mcp_info = agent_config.get('mcp_info', None)
+        tools = mcp_info.get('tools', []) if mcp_info else []
+        server_id = mcp_info.get('server_id') if mcp_info else None
         provider = os.getenv("DEFAULT_LLM_PROVIDER", "gemini")
-        
-        response_generator = self.llm_service.call_llm(
-            messages=messages,
-            system_prompt=system_prompt,
-            provider=provider
-        )
 
-        yield from response_generator
+        # Add the new user message to the conversation history.
+        messages: List[Dict[str, Any]] = llm_history + [{"role": "user", "content": message}]
+        
+        # Main loop for multi-turn tool use
+        while True:
+            response_generator = self.llm_service.call_llm(
+                messages=messages,
+                system_prompt=system_prompt,
+                provider=provider,
+                tools=tools
+            )
+
+            tool_calls_to_process = []
+            assistant_response_content = ""
+            assistant_message = {"role": "assistant", "content": None}
+
+            for chunk in response_generator:
+                if chunk["type"] == "text_chunk":
+                    yield chunk
+                    if assistant_response_content is None: assistant_response_content = ""
+                    assistant_response_content += chunk["content"]
+                elif chunk["type"] == "tool_call":
+                    tool_calls_to_process.append(chunk["tool_call"])
+                    yield chunk
+                elif chunk["type"] == "error":
+                    yield chunk
+                    return
+
+            if assistant_response_content:
+                assistant_message["content"] = assistant_response_content
+            
+            if not tool_calls_to_process:
+                break
+
+            if tool_calls_to_process:
+                tool_calls_for_history = [
+                    {"id": tc["id"], "type": "function", "function": {"name": tc["name"], "arguments": tc["arguments"]}} for tc in tool_calls_to_process
+                ]
+                assistant_message["tool_calls"] = tool_calls_for_history
+                if not assistant_response_content:
+                    assistant_message.pop("content")
+            
+            messages.append(assistant_message)
+
+            tool_results = []
+            for tool_call in tool_calls_to_process:
+                yield {"type": "tool_executing", "tool_call": tool_call}
+                
+                if not server_id:
+                    result = "Error: Agent has tools but no mcp_server_id is configured."
+                else:
+                    result = self._execute_mcp_tool(
+                        server_id, tool_call["name"], tool_call["arguments"]
+                    )
+                
+                tool_results.append({
+                    "tool_call_id": tool_call["id"],
+                    "tool_name": tool_call["name"],
+                    "content": result,
+                })
+                yield {"type": "tool_result", "tool_result": tool_results[-1]}
+
+            # Add tool results to message history for the next LLM call
+            if tool_results:
+                if provider == 'openai':
+                    for res in tool_results:
+                        # OpenAI API expects 'tool_call_id' and 'content'. The 'name' is not part of the tool message.
+                        messages.append({ "role": "tool", "tool_call_id": res["tool_call_id"], "content": res["content"] })
+                elif provider == 'anthropic':
+                    # Anthropic expects a single 'user' message containing all tool results.
+                    messages.append({
+                        "role": "user",
+                        "content": [
+                            { "type": "tool_result", "tool_use_id": res["tool_call_id"], "content": str(res["content"]) }
+                            for res in tool_results
+                        ]
+                    })
+                elif provider == 'gemini':
+                    # Gemini's 'function_response' part needs 'name' and 'content'.
+                    for res in tool_results:
+                        messages.append({
+                            "role": "tool",
+                            "tool_name": res["tool_name"],
+                            "content": res["content"],
+                            "tool_call_id": res["tool_call_id"] # Pass along for consistency, though not used in Gemini history formatting
+                        })

--- a/core/copilot_service.py
+++ b/core/copilot_service.py
@@ -1,119 +1,83 @@
 # Placeholder for AI copilot/LLM integration logic
+import json
+import os
 from typing import Dict, List, Optional, Any, Tuple
-from datetime import datetime
 
 from .data_models import Article, Collection
 from .collections_manager import CollectionsManager
 from .article_manager import ArticleManager
+from .llm_service import LLMService
 
 class CopilotService:
-    def __init__(self, collections_manager: CollectionsManager, article_manager: ArticleManager) -> None:
+    def __init__(self, collections_manager: CollectionsManager, article_manager: ArticleManager, llm_service: LLMService) -> None:
         """Initialize CopilotService with references to the managers"""
         self.collections_manager = collections_manager
         self.article_manager = article_manager
-        self.chat_history: List[Tuple[str, str]] = []  # [(user_message, assistant_message), ...]
+        self.llm_service = llm_service
+        self.agents: Dict[str, Any] = self._load_agents()
+
+    def reload(self) -> List[str]:
+        """Reloads agent configs and LLM service settings."""
+        self.llm_service.reload()
+        self.agents = self._load_agents()
+        print("Reloaded agents and LLM configurations.")
+        return self.get_agent_list()
+
+    def _load_agents(self) -> Dict[str, Any]:
+        """Load agent configurations from the agents directory."""
+        agents = {}
+        agents_dir = os.path.join(os.path.dirname(__file__), 'copilot_agents')
+        if not os.path.exists(agents_dir):
+            print(f"Warning: Agents directory not found at {agents_dir}")
+            return {}
+        for filename in os.listdir(agents_dir):
+            if filename.endswith('.json'):
+                filepath = os.path.join(agents_dir, filename)
+                with open(filepath, 'r', encoding='utf-8') as f:
+                    try:
+                        agent_config = json.load(f)
+                        if 'name' in agent_config:
+                            agents[agent_config['name']] = agent_config
+                    except json.JSONDecodeError:
+                        print(f"Warning: Could not decode JSON from {filename}")
+        return agents
+
+    def get_agent_list(self) -> List[str]:
+        """Returns a list of available agent names."""
+        return sorted(list(self.agents.keys()))
+
+    def get_agent_details(self, agent_name: str) -> Optional[Dict[str, Any]]:
+        """Returns the configuration for a specific agent."""
+        return self.agents.get(agent_name)
+
+    def chat_with_agent(self, agent_name: str, message: str, chat_history: List[List[str]]):
+        """
+        Handles a chat interaction with a specific agent using the LLMService.
+        This is now a generator function to support streaming.
+        """
+        agent_config = self.get_agent_details(agent_name)
+        if not agent_config:
+            yield "Error: Agent not found."
+            return
+
+        system_prompt = agent_config.get('model_prompt', None)
         
-    def ask(self, question: str, collection_id: Optional[str] = None, 
-            article_ids: Optional[List[str]] = None) -> str:
-        """Ask a question to the AI copilot"""
-        # For now, return a placeholder response
-        # In a real implementation, this would:
-        # 1. Get relevant articles/collections
-        # 2. Format a prompt for an LLM
-        # 3. Call the LLM and get a response
-        # 4. Format and return the response
+        # Convert Gradio history to LLM-compatible format
+        messages = []
+        for user_msg, assistant_msg in chat_history:
+            if user_msg:
+                messages.append({"role": "user", "content": user_msg})
+            if assistant_msg:
+                messages.append({"role": "assistant", "content": assistant_msg})
+        messages.append({"role": "user", "content": message})
+
+        # Get default provider from env, but can be overridden by agent config later
+        provider = os.getenv("DEFAULT_LLM_PROVIDER", "gemini")
         
-        try:
-            # Get collection details if specified
-            collection_context = ""
-            if collection_id:
-                collection = self.collections_manager.get_collection(collection_id)
-                if collection:
-                    collection_context = f"Collection: {collection.name} - {collection.description}\n"
-                    collection_context += f"Tags: {', '.join([t.name for t in collection.tags.values()])}\n"
-                    collection_context += f"Articles: {len(collection.articles)}\n"
-            
-            # Get article details if specified
-            article_context = ""
-            if collection_id and article_ids:
-                relevant_articles = []
-                for article_id in article_ids:
-                    article = self.article_manager.get_article(collection_id, article_id)
-                    if article:
-                        relevant_articles.append(article)
-                
-                if relevant_articles:
-                    article_context = "Relevant Articles:\n"
-                    for article in relevant_articles:
-                        article_context += f"- {article.title} by {', '.join(article.authors)}\n"
-            
-            # If no specific context, try to find relevant articles based on question
-            if not collection_id and not article_ids:
-                response = "Please select a collection to provide context for your question."
-                return response
-            
-            # For now, return a simple response acknowledging the question with context info
-            response = f"I understand you're asking about: {question}\n\n"
-            if collection_context:
-                response += f"Context: {collection_context}\n"
-            if article_context:
-                response += f"{article_context}\n"
-            
-            response += "In a full implementation, I would use an LLM to provide a helpful response."
-            
-            # Add to chat history
-            self.chat_history.append((question, response))
-            
-            return response
-            
-        except Exception as e:
-            return f"Error processing your question: {str(e)}"
-    
-    def get_chat_history(self) -> List[Tuple[str, str]]:
-        """Get the chat history"""
-        return self.chat_history
-    
-    def clear_chat_history(self) -> None:
-        """Clear the chat history"""
-        self.chat_history = []
-    
-    def summarize_collection(self, collection_id: str) -> str:
-        """Summarize a collection"""
-        collection = self.collections_manager.get_collection(collection_id)
-        if not collection:
-            return "Collection not found"
-        
-        # Just a placeholder - would use LLM to generate a real summary
-        summary = f"Summary of Collection: {collection.name}\n"
-        summary += f"Description: {collection.description}\n"
-        summary += f"Contains {len(collection.articles)} articles\n"
-        summary += f"Tags: {', '.join([t.name for t in collection.tags.values()])}"
-        
-        return summary
-    
-    def compare_articles(self, collection_id: str, article_ids: List[str]) -> str:
-        """Compare multiple articles"""
-        if not collection_id or not article_ids:
-            return "Please specify a collection and at least 2 articles to compare"
-        
-        collection = self.collections_manager.get_collection(collection_id)
-        if not collection:
-            return "Collection not found"
-        
-        articles = []
-        for article_id in article_ids:
-            article = self.article_manager.get_article(collection_id, article_id)
-            if article:
-                articles.append(article)
-        
-        if len(articles) < 2:
-            return "Please select at least 2 valid articles to compare"
-        
-        # Just a placeholder - would use LLM to generate a real comparison
-        comparison = f"Comparing {len(articles)} articles:\n"
-        for article in articles:
-            comparison += f"- {article.title} by {', '.join(article.authors)}\n"
-        
-        comparison += "\nIn a full implementation, I would provide a detailed comparison of these articles."
-        
-        return comparison 
+        response_generator = self.llm_service.call_llm(
+            messages=messages,
+            system_prompt=system_prompt,
+            provider=provider
+        )
+
+        yield from response_generator

--- a/core/copilot_service.py
+++ b/core/copilot_service.py
@@ -179,11 +179,9 @@ class CopilotService:
                         ]
                     })
                 elif provider == 'gemini':
-                    # Gemini's 'function_response' part needs 'name' and 'content'.
-                    for res in tool_results:
+                    # Gemini requires a single 'tool' role message containing all function responses for a given turn.
+                    if tool_results:
                         messages.append({
                             "role": "tool",
-                            "tool_name": res["tool_name"],
-                            "content": res["content"],
-                            "tool_call_id": res["tool_call_id"] # Pass along for consistency, though not used in Gemini history formatting
+                            "tool_results": tool_results
                         })

--- a/core/llm_service.py
+++ b/core/llm_service.py
@@ -1,0 +1,120 @@
+import os
+import dotenv
+import google.generativeai as genai
+import openai
+import anthropic
+import json
+from typing import List, Dict, Optional, Generator
+
+dotenv.load_dotenv()
+
+class LLMService:
+    def __init__(self):
+        self.reload()
+
+    def reload(self):
+        """Reloads API keys and default provider from .env file."""
+        print("Reloading LLM service configuration...")
+        dotenv.load_dotenv(override=True)
+        
+        self.gemini_api_key = os.getenv("GEMINI_API_KEY")
+        self.openai_api_key = os.getenv("OPENAI_API_KEY")
+        self.anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+        self.default_provider = os.getenv("DEFAULT_LLM_PROVIDER", "gemini").lower()
+
+        self.openai_client = None
+        self.anthropic_client = None
+
+        if self.gemini_api_key and self.gemini_api_key != 'your_gemini_api_key_here':
+            try:
+                genai.configure(api_key=self.gemini_api_key)
+            except Exception as e:
+                print(f"Warning: Failed to configure Gemini: {e}")
+
+        if self.openai_api_key and self.openai_api_key != 'your_openai_api_key_here':
+            self.openai_client = openai.OpenAI(api_key=self.openai_api_key)
+
+        if self.anthropic_api_key and self.anthropic_api_key != 'your_anthropic_api_key_here':
+            self.anthropic_client = anthropic.Anthropic(api_key=self.anthropic_api_key)
+
+    def call_llm(self, messages: List[Dict[str, str]], system_prompt: Optional[str] = None, provider: Optional[str] = None) -> Generator[str, None, None]:
+        provider = (provider or self.default_provider).lower()
+
+        try:
+            if provider == "gemini":
+                yield from self._call_gemini(messages, system_prompt)
+            elif provider == "openai":
+                yield from self._call_openai(messages, system_prompt)
+            elif provider == "anthropic":
+                yield from self._call_anthropic(messages, system_prompt)
+            else:
+                yield f"Error: Unsupported LLM provider '{provider}'. Supported providers are 'gemini', 'openai', 'anthropic'."
+        except Exception as e:
+            yield f"Error calling LLM provider '{provider}': {e}"
+
+    def _call_gemini(self, messages: List[Dict[str, str]], system_prompt: Optional[str]) -> Generator[str, None, None]:
+        if not self.gemini_api_key or self.gemini_api_key == 'your_gemini_api_key_here':
+            yield "Error: GEMINI_API_KEY not found or is a placeholder. Please set it in your .env file."
+            return
+        
+        model_name = 'gemini-1.5-flash'
+        model = genai.GenerativeModel(model_name=model_name, system_instruction=system_prompt)
+        
+        gemini_messages = []
+        for msg in messages:
+            role = "model" if msg["role"] == "assistant" else "user"
+            gemini_messages.append({"role": role, "parts": [msg["content"]]})
+
+        print(f"--- Calling Gemini (model: {model_name}) ---")
+        print(f"System Prompt: {system_prompt}")
+        print(f"Messages: {json.dumps(gemini_messages, indent=2)}")
+        print("------------------------------------------")
+
+        response_stream = model.generate_content(gemini_messages, stream=True)
+        for chunk in response_stream:
+            if chunk.text:
+                yield chunk.text
+
+    def _call_openai(self, messages: List[Dict[str, str]], system_prompt: Optional[str]) -> Generator[str, None, None]:
+        if not self.openai_client:
+            yield "Error: OPENAI_API_KEY not found, is a placeholder, or client not initialized. Please set it in your .env file."
+            return
+            
+        full_messages = []
+        if system_prompt:
+            full_messages.append({"role": "system", "content": system_prompt})
+        full_messages.extend(messages)
+        
+        model_name = "gpt-4o"
+        print(f"--- Calling OpenAI (model: {model_name}) ---")
+        print(f"Messages: {json.dumps(full_messages, indent=2)}")
+        print("-----------------------------------------")
+
+        stream = self.openai_client.chat.completions.create(
+            model=model_name,
+            messages=full_messages,
+            stream=True,
+        )
+        for chunk in stream:
+            if chunk.choices[0].delta.content is not None:
+                yield chunk.choices[0].delta.content
+
+    def _call_anthropic(self, messages: List[Dict[str, str]], system_prompt: Optional[str]) -> Generator[str, None, None]:
+        if not self.anthropic_client:
+            yield "Error: ANTHROPIC_API_KEY not found, is a placeholder, or client not initialized. Please set it in your .env file."
+            return
+        
+        model_name = "claude-3-haiku-20240307"
+        print(f"--- Calling Anthropic (model: {model_name}) ---")
+        print(f"System Prompt: {system_prompt}")
+        print(f"Messages: {json.dumps(messages, indent=2)}")
+        print("---------------------------------------------")
+
+        with self.anthropic_client.messages.stream(
+            model=model_name,
+            system=system_prompt,
+            messages=messages,
+            max_tokens=2048,
+        ) as stream:
+            for text in stream.text_stream:
+                yield text

--- a/core/llm_service.py
+++ b/core/llm_service.py
@@ -4,7 +4,7 @@ import google.generativeai as genai
 import openai
 import anthropic
 import json
-from typing import List, Dict, Optional, Generator
+from typing import List, Dict, Optional, Generator, Any
 
 dotenv.load_dotenv()
 
@@ -13,14 +13,20 @@ class LLMService:
         self.reload()
 
     def reload(self):
-        """Reloads API keys and default provider from .env file."""
+        """Reloads API keys, models, and provider from .env file."""
         print("Reloading LLM service configuration...")
         dotenv.load_dotenv(override=True)
         
+        # API Keys
         self.gemini_api_key = os.getenv("GEMINI_API_KEY")
         self.openai_api_key = os.getenv("OPENAI_API_KEY")
         self.anthropic_api_key = os.getenv("ANTHROPIC_API_KEY")
+        
+        # Provider and Models
         self.default_provider = os.getenv("DEFAULT_LLM_PROVIDER", "gemini").lower()
+        self.gemini_model = os.getenv("GEMINI_MODEL", "gemini-1.5-flash")
+        self.openai_model = os.getenv("OPENAI_MODEL", "gpt-4o")
+        self.anthropic_model = os.getenv("ANTHROPIC_MODEL", "claude-3-haiku-20240307")
 
         self.openai_client = None
         self.anthropic_client = None
@@ -37,84 +43,216 @@ class LLMService:
         if self.anthropic_api_key and self.anthropic_api_key != 'your_anthropic_api_key_here':
             self.anthropic_client = anthropic.Anthropic(api_key=self.anthropic_api_key)
 
-    def call_llm(self, messages: List[Dict[str, str]], system_prompt: Optional[str] = None, provider: Optional[str] = None) -> Generator[str, None, None]:
+    def call_llm(self, messages: List[Dict[str, any]], system_prompt: Optional[str] = None, provider: Optional[str] = None, tools: Optional[List[Dict[str, Any]]] = None) -> Generator[Dict, None, None]:
         provider = (provider or self.default_provider).lower()
 
         try:
             if provider == "gemini":
-                yield from self._call_gemini(messages, system_prompt)
+                yield from self._call_gemini(messages, system_prompt, tools)
             elif provider == "openai":
-                yield from self._call_openai(messages, system_prompt)
+                yield from self._call_openai(messages, system_prompt, tools)
             elif provider == "anthropic":
-                yield from self._call_anthropic(messages, system_prompt)
+                yield from self._call_anthropic(messages, system_prompt, tools)
             else:
-                yield f"Error: Unsupported LLM provider '{provider}'. Supported providers are 'gemini', 'openai', 'anthropic'."
+                yield {"type": "error", "content": f"Error: Unsupported LLM provider '{provider}'. Supported providers are 'gemini', 'openai', 'anthropic'."}
         except Exception as e:
-            yield f"Error calling LLM provider '{provider}': {e}"
+            error_message = f"Error calling LLM provider '{provider}': {e}"
+            print(f"ERROR: {error_message}")
+            yield {"type": "error", "content": error_message}
 
-    def _call_gemini(self, messages: List[Dict[str, str]], system_prompt: Optional[str]) -> Generator[str, None, None]:
+    def _call_gemini(self, messages: List[Dict[str, Any]], system_prompt: Optional[str], tools: Optional[List[Dict[str, Any]]]) -> Generator[Dict, None, None]:
         if not self.gemini_api_key or self.gemini_api_key == 'your_gemini_api_key_here':
-            yield "Error: GEMINI_API_KEY not found or is a placeholder. Please set it in your .env file."
+            yield {"type": "error", "content": "Error: GEMINI_API_KEY not found or is a placeholder. Please set it in your .env file."}
             return
         
-        model_name = 'gemini-1.5-flash'
-        model = genai.GenerativeModel(model_name=model_name, system_instruction=system_prompt)
+        model_name = self.gemini_model
+        model_kwargs = {}
+        if system_prompt:
+            model_kwargs['system_instruction'] = system_prompt
+        if tools:
+            # The genai SDK expects a specific format for tools.
+            gemini_tools = [{"function_declarations": [
+                {
+                    "name": tool["name"],
+                    "description": tool["description"],
+                    "parameters": tool["inputSchema"]
+                } for tool in tools
+            ]}]
+            model_kwargs['tools'] = gemini_tools
         
+        model = genai.GenerativeModel(model_name=model_name, **model_kwargs)
+        
+        # Convert the generic message history to the format Gemini's SDK expects.
         gemini_messages = []
         for msg in messages:
-            role = "model" if msg["role"] == "assistant" else "user"
-            gemini_messages.append({"role": role, "parts": [msg["content"]]})
+            role = "model" if msg["role"] == "assistant" else msg["role"]
+            
+            if role == "tool":
+                gemini_messages.append({
+                    "role": "tool",
+                    "parts": [{
+                        "function_response": {
+                            "name": msg["tool_name"],
+                            "response": {"content": msg["content"]},
+                        }
+                    }]
+                })
+            elif msg.get("tool_calls"): # Assistant message with tool calls
+                parts = [{
+                    "function_call": {
+                        "name": tc['function']['name'], 
+                        "args": tc['function']['arguments']
+                    }
+                } for tc in msg['tool_calls']]
+                gemini_messages.append({"role": role, "parts": parts})
+            else: # Regular user/assistant text message
+                content = msg.get("content")
+                if content is not None:
+                     gemini_messages.append({"role": role, "parts": [{"text": str(content)}]})
 
         print(f"--- Calling Gemini (model: {model_name}) ---")
-        print(f"System Prompt: {system_prompt}")
         print(f"Messages: {json.dumps(gemini_messages, indent=2)}")
         print("------------------------------------------")
 
         response_stream = model.generate_content(gemini_messages, stream=True)
         for chunk in response_stream:
-            if chunk.text:
-                yield chunk.text
+            if chunk.parts:
+                for part in chunk.parts:
+                    if part.text:
+                        yield {"type": "text_chunk", "content": part.text}
+                    elif part.function_call:
+                        yield {
+                            "type": "tool_call",
+                            "tool_call": {
+                                "id": f"call_{part.function_call.name}_{os.urandom(4).hex()}", # Gemini doesn't provide a call ID
+                                "name": part.function_call.name,
+                                "arguments": dict(part.function_call.args),
+                            }
+                        }
 
-    def _call_openai(self, messages: List[Dict[str, str]], system_prompt: Optional[str]) -> Generator[str, None, None]:
+    def _call_openai(self, messages: List[Dict[str, any]], system_prompt: Optional[str], tools: Optional[List[Dict[str, Any]]]) -> Generator[Dict, None, None]:
         if not self.openai_client:
-            yield "Error: OPENAI_API_KEY not found, is a placeholder, or client not initialized. Please set it in your .env file."
+            yield {"type": "error", "content": "Error: OPENAI_API_KEY not found, is a placeholder, or client not initialized. Please set it in your .env file."}
             return
-            
+
         full_messages = []
         if system_prompt:
             full_messages.append({"role": "system", "content": system_prompt})
-        full_messages.extend(messages)
+
+        for m in messages:
+            if m["role"] == "assistant" and "tool_calls" in m:
+                full_messages.append(m)
+            elif m["role"] == "tool":
+                full_messages.append({
+                    "role": "tool",
+                    "tool_call_id": m["tool_call_id"],
+                    "content": m["content"]
+                })
+            else: # user or regular assistant message
+                full_messages.append({"role": m["role"], "content": m["content"]})
         
-        model_name = "gpt-4o"
+        model_name = self.openai_model
+        
+        request_params = {
+            "model": model_name,
+            "messages": full_messages,
+            "stream": True,
+        }
+        
+        if tools:
+            openai_tools = [{"type": "function", "function": {"name": t["name"], "description": t["description"], "parameters": t["inputSchema"]}} for t in tools]
+            request_params["tools"] = openai_tools
+            request_params["tool_choice"] = "auto"
+
         print(f"--- Calling OpenAI (model: {model_name}) ---")
         print(f"Messages: {json.dumps(full_messages, indent=2)}")
+        print(f"Tools: {json.dumps(tools, indent=2)}")
         print("-----------------------------------------")
+        
+        try:
+            stream = self.openai_client.chat.completions.create(**request_params)
+            
+            tool_calls = []
+            for chunk in stream:
+                delta = chunk.choices[0].delta
+                if delta.content is not None:
+                    yield {"type": "text_chunk", "content": delta.content}
+                
+                if delta.tool_calls:
+                    for tool_call_chunk in delta.tool_calls:
+                        if tool_call_chunk.index >= len(tool_calls):
+                            tool_calls.append({"id": "", "type": "function", "function": {"name": "", "arguments": ""}})
+                        
+                        tc = tool_calls[tool_call_chunk.index]
+                        if tool_call_chunk.id:
+                            tc["id"] = tool_call_chunk.id
+                        if tool_call_chunk.function.name:
+                            tc["function"]["name"] += tool_call_chunk.function.name
+                        if tool_call_chunk.function.arguments:
+                            tc["function"]["arguments"] += tool_call_chunk.function.arguments
 
-        stream = self.openai_client.chat.completions.create(
-            model=model_name,
-            messages=full_messages,
-            stream=True,
-        )
-        for chunk in stream:
-            if chunk.choices[0].delta.content is not None:
-                yield chunk.choices[0].delta.content
+            if tool_calls:
+                for tc in tool_calls:
+                    yield {
+                        "type": "tool_call",
+                        "tool_call": {
+                            "id": tc["id"],
+                            "name": tc["function"]["name"],
+                            "arguments": json.loads(tc["function"]["arguments"]),
+                        }
+                    }
+        except Exception as e:
+            yield {"type": "error", "content": f"OpenAI API Error: {str(e)}"}
 
-    def _call_anthropic(self, messages: List[Dict[str, str]], system_prompt: Optional[str]) -> Generator[str, None, None]:
+    def _call_anthropic(self, messages: List[Dict[str, any]], system_prompt: Optional[str], tools: Optional[List[Dict[str, Any]]]) -> Generator[Dict, None, None]:
         if not self.anthropic_client:
-            yield "Error: ANTHROPIC_API_KEY not found, is a placeholder, or client not initialized. Please set it in your .env file."
+            yield {"type": "error", "content": "Error: ANTHROPIC_API_KEY not found, is a placeholder, or client not initialized. Please set it in your .env file."}
             return
         
-        model_name = "claude-3-haiku-20240307"
+        # The 'messages' list is expected to be pre-formatted by the calling service,
+        # especially for tool results, which should be in Anthropic's specific format.
+        anthropic_messages = messages
+
+        model_name = self.anthropic_model
+        
+        api_kwargs = {
+            "model": model_name,
+            "system": system_prompt,
+            "messages": anthropic_messages,
+            "max_tokens": 4096,
+        }
+        if tools:
+            # Convert to Anthropic's 'input_schema' format.
+            anthropic_tools = []
+            for tool in tools:
+                new_tool = tool.copy()
+                new_tool['input_schema'] = new_tool.pop('inputSchema')
+                anthropic_tools.append(new_tool)
+            api_kwargs["tools"] = anthropic_tools
+
         print(f"--- Calling Anthropic (model: {model_name}) ---")
-        print(f"System Prompt: {system_prompt}")
-        print(f"Messages: {json.dumps(messages, indent=2)}")
+        print(f"Messages: {json.dumps(anthropic_messages, indent=2)}")
         print("---------------------------------------------")
 
-        with self.anthropic_client.messages.stream(
-            model=model_name,
-            system=system_prompt,
-            messages=messages,
-            max_tokens=2048,
-        ) as stream:
-            for text in stream.text_stream:
-                yield text
+        with self.anthropic_client.messages.stream(**api_kwargs) as stream:
+            for event in stream:
+                if event.type == 'content_block_delta':
+                    if event.delta.type == 'text_delta':
+                        yield {"type": "text_chunk", "content": event.delta.text}
+                elif event.type == 'message_delta' and event.delta.stop_reason == "tool_use":
+                    # This event contains the full tool calls, not a delta
+                    for content_block in event.message.content:
+                        if content_block.type == 'tool_use':
+                             yield {
+                                "type": "tool_call",
+                                "tool_call": {
+                                    "id": content_block.id,
+                                    "name": content_block.name,
+                                    "arguments": content_block.input,
+                                }
+                            }
+                elif event.type == 'content_block_start':
+                    if event.content_block.type == 'tool_use':
+                        # First chunk of a tool call comes in a content_block_start
+                        # But we will use the full tool_use from message_delta
+                        pass

--- a/core/mcp_server_manager.py
+++ b/core/mcp_server_manager.py
@@ -35,11 +35,16 @@ class MCPServerManager:
     def _discover_managed_servers(self) -> Dict[str, Dict[str, Any]]:
         servers_dir = os.path.join(os.path.dirname(__file__), 'mcp_servers')
         calculator_script = os.path.join(servers_dir, 'calculator_server.py')
+        csv_script = os.path.join(servers_dir, 'csv_server.py')
 
         return {
             "managed_calculator": {
                 "command": sys.executable,
                 "args": [calculator_script],
+            },
+            "managed_csv": {
+                "command": sys.executable,
+                "args": [csv_script],
             }
         }
 

--- a/core/mcp_server_manager.py
+++ b/core/mcp_server_manager.py
@@ -1,0 +1,94 @@
+import sys
+import os
+import asyncio
+import atexit
+import threading
+from typing import Dict, Optional, Any, Coroutine
+from contextlib import AsyncExitStack
+from concurrent.futures import Future
+
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+class MCPServerManager:
+    def __init__(self):
+        self.server_configs: Dict[str, Dict[str, Any]] = self._discover_managed_servers()
+        self.active_sessions: Dict[str, ClientSession] = {}
+        self.exit_stack = AsyncExitStack()
+
+        self._loop = asyncio.new_event_loop()
+        self._thread = threading.Thread(target=self._loop.run_forever, daemon=True)
+        self._thread.start()
+
+        atexit.register(self.shutdown)
+
+    def run_coroutine_and_get_result(self, coro: Coroutine) -> Any:
+        """Runs a coroutine on the manager's event loop and returns the result."""
+        future: Future = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        try:
+            # Using a timeout to prevent indefinite blocking
+            return future.result(timeout=60)
+        except Exception as e:
+            future.cancel()
+            raise e
+
+    def _discover_managed_servers(self) -> Dict[str, Dict[str, Any]]:
+        servers_dir = os.path.join(os.path.dirname(__file__), 'mcp_servers')
+        calculator_script = os.path.join(servers_dir, 'calculator_server.py')
+
+        return {
+            "managed_calculator": {
+                "command": sys.executable,
+                "args": [calculator_script],
+            }
+        }
+
+    async def get_session(self, server_id: str) -> Optional[ClientSession]:
+        if server_id in self.active_sessions:
+            return self.active_sessions[server_id]
+
+        server_config = self.server_configs.get(server_id)
+        if not server_config:
+            print(f"Error: No configuration found for server_id '{server_id}'")
+            return None
+        
+        try:
+            print(f"Creating new MCP session for '{server_id}'...")
+            server_params = StdioServerParameters(
+                command=server_config["command"],
+                args=server_config["args"],
+            )
+
+            # The exit stack will manage the lifecycle of these async context managers
+            stdio_transport = await self.exit_stack.enter_async_context(stdio_client(server_params))
+            session = await self.exit_stack.enter_async_context(ClientSession(stdio_transport[0], stdio_transport[1]))
+            
+            await session.initialize()
+            print(f"MCP session for '{server_id}' initialized successfully.")
+            self.active_sessions[server_id] = session
+            return session
+        except Exception as e:
+            print(f"Error creating MCP session for '{server_id}': {e}")
+            return None
+
+    async def stop_all_async(self):
+        print("Stopping all managed MCP sessions...")
+        await self.exit_stack.aclose()
+        self.active_sessions.clear()
+        print("All MCP sessions stopped.")
+
+    def shutdown(self):
+        """Stops all servers and shuts down the event loop."""
+        if not self._loop.is_running():
+            return
+        
+        print("Shutting down MCP Server Manager...")
+        try:
+            self.run_coroutine_and_get_result(self.stop_all_async())
+        except Exception as e:
+            print(f"Error during MCP session shutdown: {e}")
+        finally:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._thread.join(timeout=5)
+            self._loop.close()
+            print("MCP Server Manager shut down.")

--- a/core/mcp_servers/calculator_server.py
+++ b/core/mcp_servers/calculator_server.py
@@ -1,0 +1,40 @@
+import math
+import sys
+from mcp.server.fastmcp import FastMCP
+
+# Use the high-level FastMCP helper for robust server creation
+mcp = FastMCP("standard-calculator-server")
+
+def _calculate_expression(expression: str) -> str:
+    """The actual implementation of the calculator."""
+    try:
+        # A safer eval environment
+        allowed_names = {k: v for k, v in math.__dict__.items() if not k.startswith("__")}
+        allowed_names["abs"] = abs
+        
+        if len(expression) > 200:
+            raise ValueError("Expression is too long.")
+            
+        result = eval(expression, {"__builtins__": {}}, allowed_names)
+        return str(result)
+    except Exception as e:
+        # Raise a ValueError, which FastMCP will convert into a proper tool error response.
+        raise ValueError(f"Invalid expression: {e}") from e
+
+@mcp.tool()
+async def calculate(expression: str) -> str:
+    """
+    Performs a mathematical calculation. The input should be a single string 
+    representing a valid mathematical expression (e.g., '2 + 2', '10 * (4 - 2)', 'sqrt(16)').
+    """
+    return _calculate_expression(expression)
+
+if __name__ == "__main__":
+    try:
+        # The run method handles the server lifecycle, including initialization and transport.
+        mcp.run(transport='stdio')
+    except KeyboardInterrupt:
+        print("Calculator server shutting down.")
+    except Exception as e:
+        print(f"Calculator server crashed with error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/core/mcp_servers/csv_server.py
+++ b/core/mcp_servers/csv_server.py
@@ -1,0 +1,114 @@
+import os
+import sys
+from io import StringIO
+import pandas as pd
+from mcp.server.fastmcp import FastMCP
+
+# This will hold the loaded dataframe. A class-based approach would be better for
+# handling multiple files or sessions, but a simple dict is fine for this example.
+state = {"dataframe": None, "filename": None}
+
+mcp = FastMCP("csv-assistant-server")
+
+@mcp.tool()
+async def load_csv(file_path: str) -> str:
+    """
+    Loads a CSV file from the local filesystem into memory for querying.
+    Expands user home directory `~`.
+    
+    Args:
+        file_path: The local path to the CSV file (e.g., '~/Downloads/data.csv').
+    """
+    expanded_path = os.path.expanduser(file_path)
+    if not os.path.exists(expanded_path):
+        raise ValueError(f"File not found at path: {expanded_path}")
+    
+    try:
+        df = pd.read_csv(expanded_path)
+        state["dataframe"] = df
+        state["filename"] = os.path.basename(expanded_path)
+        return f"Successfully loaded '{state['filename']}' with {len(df)} rows and {len(df.columns)} columns."
+    except Exception as e:
+        raise ValueError(f"Failed to load or parse CSV file: {e}") from e
+
+def _ensure_df_loaded():
+    """Helper function to check if a DataFrame is loaded."""
+    if state["dataframe"] is None:
+        raise ValueError("No CSV file loaded. Please use 'load_csv' first.")
+    return state["dataframe"]
+
+@mcp.tool()
+async def get_csv_headers() -> str:
+    """
+    Returns the column headers of the currently loaded CSV file as a comma-separated string.
+    """
+    df = _ensure_df_loaded()
+    return ", ".join(df.columns)
+
+@mcp.tool()
+async def show_head(rows: int = 5) -> str:
+    """
+    Displays the first few rows of the loaded CSV file.
+    
+    Args:
+        rows: The number of rows to display from the top of the file. Defaults to 5.
+    """
+    df = _ensure_df_loaded()
+    return df.head(rows).to_string()
+
+@mcp.tool()
+async def get_summary() -> str:
+    """
+    Provides a summary of the loaded CSV file, including column data types, non-null counts, and descriptive statistics for numerical columns.
+    """
+    df = _ensure_df_loaded()
+    
+    info_buffer = StringIO()
+    df.info(buf=info_buffer)
+    info_str = info_buffer.getvalue()
+
+    numeric_cols = df.select_dtypes(include='number')
+    if not numeric_cols.empty:
+        describe_str = numeric_cols.describe().to_string()
+    else:
+        describe_str = "No numerical columns to describe."
+    
+    return f"File: {state['filename']}\n\n=== Dataframe Info ===\n{info_str}\n\n=== Descriptive Statistics (for numerical columns) ===\n{describe_str}"
+
+
+@mcp.tool()
+async def query_data(query_expression: str) -> str:
+    """
+    Queries the loaded CSV data using a pandas query expression.
+    Example: 'Age > 30', '`Country` == "USA" and `Salary` > 50000'.
+    Column names with spaces or special characters should be enclosed in backticks ``.
+    
+    Args:
+        query_expression: A string containing the pandas query expression.
+    """
+    df = _ensure_df_loaded()
+    try:
+        # Using the 'numexpr' engine which is generally safer and faster.
+        result_df = df.query(query_expression, engine='numexpr')
+        
+        if result_df.empty:
+            return "Query returned no results."
+        
+        # Limit output size to prevent flooding the context
+        if len(result_df) > 50:
+             return f"Query returned {len(result_df)} rows. Showing first 50.\n\n{result_df.head(50).to_string()}"
+             
+        return result_df.to_string()
+    except Exception as e:
+        if "undefined variable" in str(e).lower():
+             return f"Error: Invalid query. One of the column names might be misspelled or needs backticks for special characters (e.g., `Column Name`). Details: {e}"
+        raise ValueError(f"Invalid query expression: {e}") from e
+
+if __name__ == "__main__":
+    try:
+        mcp.run(transport='stdio')
+    except KeyboardInterrupt:
+        print("CSV server shutting down.")
+    except Exception as e:
+        print(f"CSV server crashed with error: {e}", file=sys.stderr)
+        sys.exit(1)

--- a/ui/custom_css.py
+++ b/ui/custom_css.py
@@ -77,8 +77,76 @@ button:has(> span:contains('Get Report')) {
     word-wrap: break-word !important;
 }
 
-#copilot-reload-button {
-    max-width: 2.5em; /* Adjust size of reload button */
-    min-width: 2.5em !important;
+/* Agent List Styles */
+#agent-list-container .agent-list-container {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.agent-item {
+    display: flex;
+    align-items: center;
+    padding: 12px;
+    border-radius: 8px;
+    border: 1px solid var(--border-color-primary);
+    cursor: pointer;
+    transition: background-color 0.2s, border-color 0.2s, box-shadow 0.2s;
+    /* By not setting a background-color, it will inherit and work in dark mode. */
+}
+
+.agent-item:hover {
+    background-color: var(--background-fill-secondary);
+}
+
+.agent-item.selected {
+    border-color: var(--primary-500);
+    /* background-color is removed to avoid contrast issues in dark mode */
+    box-shadow: 0 0 0 1px var(--primary-500);
+}
+
+.agent-icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    margin-right: 12px;
+    flex-shrink: 0;
+}
+
+.agent-text {
+    display: flex;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.agent-name {
+    font-weight: 600;
+    color: var(--body-text-color-strong);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.agent-description {
+    font-size: 0.9em;
+    color: var(--body-text-color);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Custom style for the discrete reload button */
+.discrete-reload-button {
+    background: transparent !important;
+    border: 1px solid var(--border-color-primary) !important;
+    color: var(--body-text-color) !important;
+    box-shadow: none !important;
+    font-weight: 500 !important;
+}
+
+.discrete-reload-button:hover {
+    background: var(--background-fill-secondary) !important;
+    border-color: var(--primary-500) !important;
+    color: var(--body-text-color-strong) !important;
 }
 '''

--- a/ui/custom_css.py
+++ b/ui/custom_css.py
@@ -50,4 +50,35 @@ button:has(> span:contains('Get Report')) {
   content: '\1F5FA  '; /* 🗺️ */
   font-size: 1.1em;
 }
-''' 
+
+/* Copilot Tab specific styles */
+#copilot-main-container {
+    height: calc(100vh - 250px); /* Adjust offset for header/tabs etc. */
+}
+
+#copilot-main-container > div { /* Target direct children columns */
+    height: 100%;
+}
+
+#copilot-chat-column {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+#copilot_chatbot {
+    flex-grow: 1;
+    overflow-y: auto;
+    height: 100%;
+}
+
+#agent-details-display pre code {
+    white-space: pre-wrap !important;
+    word-wrap: break-word !important;
+}
+
+#copilot-reload-button {
+    max-width: 2.5em; /* Adjust size of reload button */
+    min-width: 2.5em !important;
+}
+'''

--- a/ui/ui_copilot.py
+++ b/ui/ui_copilot.py
@@ -1,24 +1,112 @@
 import gradio as gr
 from core.copilot_service import CopilotService
 import json
+import hashlib
+
+# Defines a Gradio-compliant way to run JavaScript for component interaction.
+# The JS is defined as a string and passed to an event listener's `js` parameter.
+_js_attach_listener = """
+() => {
+  // We wrap our code in a setTimeout to ensure it runs after Gradio has
+  // finished rendering the HTML from the Python event on the page.
+  setTimeout(() => {
+    const container = document.getElementById('agent-list-container');
+    if (!container) return;
+
+    // Prevent attaching multiple listeners if the component is re-rendered.
+    if (container.dataset.listenerAttached === 'true') return;
+    container.dataset.listenerAttached = 'true';
+
+    container.addEventListener('click', (event) => {
+      const agentItem = event.target.closest('.agent-item');
+      if (!agentItem) return;
+
+      const agentName = agentItem.dataset.agentName;
+      if (!agentName) return;
+
+      const hiddenTextbox = document.querySelector('#copilot_selected_agent_trigger');
+      if (!hiddenTextbox) return;
+
+      // A gr.Textbox can be rendered as either an <input> or a <textarea>.
+      // This more robust selector finds whichever one is present.
+      const hiddenInput = hiddenTextbox.querySelector('input[type="text"], textarea');
+      if (!hiddenInput) return;
+
+      if (hiddenInput.value !== agentName) {
+        hiddenInput.value = agentName;
+        hiddenInput.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    });
+  }, 150);
+}
+"""
+
+def name_to_color(name: str) -> str:
+    """Generates a deterministic, somewhat pleasant color from a string."""
+    hash_object = hashlib.md5(name.encode())
+    hex_dig = hash_object.hexdigest()
+    # Skew towards softer, pastel-like colors by ensuring components are not too dark
+    r = (int(hex_dig[0:2], 16) % 150) + 50
+    g = (int(hex_dig[2:4], 16) % 150) + 50
+    b = (int(hex_dig[4:6], 16) % 150) + 50
+    return f"rgb({r},{g},{b})"
+
+def generate_agent_list_html(copilot_service: CopilotService, selected_agent_name: str) -> str:
+    """Generates an HTML block for the agent selection list."""
+    agent_list = copilot_service.get_agent_list()
+    html_items = []
+    for agent_name in agent_list:
+        details = copilot_service.get_agent_details(agent_name)
+        if not details:
+            continue
+
+        is_selected_class = "selected" if agent_name == selected_agent_name else ""
+        color = name_to_color(agent_name)
+        description = details.get('description', 'No description.')
+        # Escape double quotes for safe insertion into the data attribute
+        safe_agent_name = agent_name.replace('"', '&quot;')
+        
+        # The click event is handled by a listener attached via JS, using the `data-agent-name` attribute.
+        html_items.append(f"""
+        <div class="agent-item {is_selected_class}" data-agent-name="{safe_agent_name}">
+            <div class="agent-icon" style="background-color: {color};"></div>
+            <div class="agent-text">
+                <div class="agent-name">{agent_name}</div>
+                <div class="agent-description">{description}</div>
+            </div>
+        </div>
+        """)
+    
+    return f"<div class='agent-list-container'>{''.join(html_items)}</div>"
+
 
 def create_copilot_tab(state, copilot_service: CopilotService):
     with gr.TabItem("🤖 AI Copilot") as copilot_tab:
         with gr.Blocks(theme=gr.themes.Soft()):
             with gr.Row(equal_height=False, elem_id="copilot-main-container"):
-                with gr.Column(scale=1, min_width=250):
+                with gr.Column(scale=1, min_width=320):
                     with gr.Row():
                         gr.Markdown("### Agents")
-                        reload_button = gr.Button("🔄", variant="tool", elem_id="copilot-reload-button")
+                        # This spacer div will grow to push the button to the right.
+                        gr.HTML("<div style='flex-grow: 1'></div>")
+                        with gr.Column(scale=0, min_width=120): # Wrap button in a non-expanding column
+                            reload_button = gr.Button("Reload Agents", size="sm", elem_classes="discrete-reload-button")
 
                     agent_list = copilot_service.get_agent_list()
+                    initial_agent = agent_list[0] if agent_list else None
                     
-                    selected_agent_name = gr.Radio(
-                        agent_list,
-                        label="Select Agent",
-                        value=agent_list[0] if agent_list else None,
-                        elem_id="copilot-agent-selector"
+                    # State to hold the name of the currently selected agent
+                    selected_agent_name_state = gr.State(initial_agent)
+                    
+                    # Hidden Textbox to receive selection events from JS
+                    selected_agent_trigger = gr.Textbox(
+                        label="selected_agent_trigger",
+                        visible=False,
+                        elem_id="copilot_selected_agent_trigger"
                     )
+
+                    # UI component to display the HTML list
+                    agent_list_display = gr.HTML(elem_id="agent-list-container")
 
                     with gr.Accordion("Agent Details", open=True):
                         agent_details_display = gr.Markdown("Select an agent to see details.", elem_id="agent-details-display")
@@ -28,10 +116,11 @@ def create_copilot_tab(state, copilot_service: CopilotService):
                         [],
                         elem_id="copilot_chatbot",
                         bubble_full_width=False,
-                        # height is now controlled by CSS for responsiveness
+                        # The height is controlled by CSS for responsiveness.
                         label="Copilot Chat",
                         show_copy_button=True
                     )
+                    conversation_history_state = gr.State([])
                     
                     with gr.Row():
                         chat_input = gr.Textbox(
@@ -43,83 +132,250 @@ def create_copilot_tab(state, copilot_service: CopilotService):
                         send_button = gr.Button("Send", scale=1, variant="primary")
 
             # --- Event Handlers ---
-            def on_select_agent(agent_name):
+            def on_select_agent(agent_name, current_selected_agent):
+                # If the agent is already selected, do nothing to avoid clearing the chat.
+                if agent_name == current_selected_agent:
+                    return gr.update(), gr.update(), gr.update(), gr.update(), gr.update()
+                
                 agent_details = copilot_service.get_agent_details(agent_name)
                 if not agent_details:
-                    return "No details available.", []
-                
+                    no_details_md = "Agent details not found."
+                    return no_details_md, [], [], agent_name, generate_agent_list_html(copilot_service, agent_name)
+
+                # --- UI Update ---
                 details_md = f"**{agent_details.get('name', 'N/A')}**\n\n"
                 details_md += f"*{agent_details.get('description', 'No description.')}*\n\n"
-                if agent_details.get('model_prompt', ""):
-                    details_md += f"**System Prompt:**\n```\n{agent_details.get('model_prompt')}\n```"
                 
-                return details_md, [] # returns details and clears chat history
+                if agent_details.get('model_prompt'):
+                    details_md += f"**System Prompt:**\n```\n{agent_details.get('model_prompt')}\n```\n"
 
-            def on_chat_message(agent_name, message, history):
+                mcp_info = agent_details.get('mcp_info', None)
+                tools = mcp_info.get('tools', []) if mcp_info else []
+                if tools:
+                    details_md += "\n**Available Tools:**\n"
+                    for tool in tools:
+                        details_md += f"- `{tool.get('name')}`: {tool.get('description', 'No description.')}\n"
+                
+                # --- Console Logging ---
+                print(f"\n--- Switched to Agent: {agent_name} ---")
+                print(f"System Prompt: {agent_details.get('model_prompt', 'None')}")
+                print(f"Tools: {json.dumps(tools, indent=2)}")
+                print("------------------------------------------")
+                
+                return (
+                    details_md, 
+                    [], 
+                    [], 
+                    agent_name, 
+                    generate_agent_list_html(copilot_service, agent_name)
+                )
+
+            def on_chat_message(agent_name, message, ui_history, llm_history):
                 if not message.strip():
-                    # Return updates for all outputs to avoid errors
-                    yield history, gr.update(), gr.update()
+                    yield ui_history, gr.update(), gr.update(), llm_history
                     return
 
-                history.append([message, None])
-                # Disable inputs during processing
-                yield history, gr.update(interactive=False), gr.update(interactive=False)
-                
+                ui_history.append([message, None])
+                yield ui_history, gr.update(interactive=False), gr.update(interactive=False), llm_history
+
                 if not agent_name:
-                    history[-1][1] = "Please select an agent first."
-                    # Re-enable inputs if no agent is selected
-                    yield history, gr.update(interactive=True), gr.update(interactive=True)
+                    ui_history[-1][1] = "Please select an agent first."
+                    yield ui_history, gr.update(interactive=True), gr.update(interactive=True), llm_history
                     return
 
-                user_message = history[-1][0]
-                service_history = [h for h in history[:-1] if h[1] is not None]
+                response_generator = copilot_service.chat_with_agent(agent_name, message, llm_history)
                 
-                # Stream the response
-                history[-1][1] = ""
-                response_generator = copilot_service.chat_with_agent(agent_name, user_message, service_history)
-                for token in response_generator:
-                    history[-1][1] += token
-                    yield history, gr.update(interactive=False), gr.update(interactive=False)
+                # State for processing this turn's response
+                full_assistant_message = {"role": "assistant", "content": None}
+                assembled_tool_calls = []
+                is_first_assistant_bubble = True
+                last_bubble_was_text = False
+                tool_call_ui_map = {}  # Maps tool_call_id to {'index': int, 'call': dict}
 
-                # Re-enable inputs after streaming is done
-                yield history, gr.update(interactive=True), gr.update(interactive=True)
+                for chunk in response_generator:
+                    if chunk['type'] == 'text_chunk':
+                        if not last_bubble_was_text:
+                            # New text bubble needed after a tool call or at the start
+                            if is_first_assistant_bubble:
+                                ui_history[-1][1] = chunk['content']
+                            else:
+                                ui_history.append([None, chunk['content']])
+                            is_first_assistant_bubble = False
+                            last_bubble_was_text = True
+                        else:
+                            # Append to the existing text bubble
+                            ui_history[-1][1] += chunk['content']
+                        
+                        # Assemble content for the final LLM history object
+                        if full_assistant_message["content"] is None:
+                            full_assistant_message["content"] = ""
+                        full_assistant_message["content"] += chunk['content']
 
-            def on_reload_config():
-                new_agent_list = copilot_service.reload()
-                new_selected_agent = new_agent_list[0] if new_agent_list else None
+                    elif chunk['type'] == 'tool_call':
+                        last_bubble_was_text = False
+                        tool_call = chunk['tool_call']
+
+                        # Assemble tool call for LLM history
+                        assembled_tool_calls.append({
+                            "id": tool_call["id"], "type": "function", 
+                            "function": {"name": tool_call["name"], "arguments": tool_call["arguments"]}
+                        })
+
+                        # Create a new, dedicated bubble for this tool call, using HTML for a collapsible section
+                        tool_md = f"""<details>
+<summary>🛠️ Calling Tool: <code>{tool_call['name']}</code></summary>
+<br>
+
+**Arguments:**
+```json
+{json.dumps(tool_call['arguments'], indent=2)}
+```
+</details>"""
+                        if is_first_assistant_bubble:
+                            ui_history[-1][1] = tool_md
+                        else:
+                            ui_history.append([None, tool_md])
+                        
+                        is_first_assistant_bubble = False
+                        tool_call_ui_map[tool_call['id']] = {'index': len(ui_history) - 1, 'call': tool_call}
+
+                    elif chunk['type'] == 'tool_result':
+                        tool_result = chunk['tool_result']
+                        tool_call_id = tool_result['tool_call_id']
+                        if tool_call_id in tool_call_ui_map:
+                            bubble_info = tool_call_ui_map[tool_call_id]
+                            bubble_index = bubble_info['index']
+                            original_call = bubble_info['call']
+                            
+                            content = tool_result['content']
+                            try:
+                                # Try to pretty-print if the content is JSON
+                                parsed_content = json.loads(content)
+                                content_md = f"```json\n{json.dumps(parsed_content, indent=2)}\n```"
+                            except (json.JSONDecodeError, TypeError):
+                                content_md = f"```\n{str(content)}\n```"
+
+                            # Re-render the bubble content with the result, making it temporarily expanded
+                            tool_md_with_result = f"""<details open>
+<summary>✅ Tool Call Succeeded: <code>{original_call['name']}</code></summary>
+<br>
+
+**Arguments:**
+```json
+{json.dumps(original_call['arguments'], indent=2)}
+```
+
+**Result:**
+{content_md}
+<br>🤔 Thinking...
+</details>"""
+                            ui_history[bubble_index][1] = tool_md_with_result
+                    
+                    elif chunk['type'] == 'error':
+                        if ui_history[-1][1] is None: ui_history[-1][1] = ""
+                        ui_history[-1][1] += f"\n\nAn error occurred: {chunk['content']}"
+                        yield ui_history, gr.update(interactive=True), gr.update(interactive=True), llm_history
+                        return
+
+                    yield ui_history, gr.update(interactive=False), gr.update(interactive=False), llm_history
+
+                # Finalize the full assistant message for LLM history
+                if assembled_tool_calls:
+                    full_assistant_message["tool_calls"] = assembled_tool_calls
+                    if full_assistant_message["content"] is None:
+                        full_assistant_message.pop("content")
                 
-                if new_selected_agent:
-                    details_md, _ = on_select_agent(new_selected_agent)
+                # Clean up tool bubbles: remove "Thinking..." and collapse details
+                for bubble_info in tool_call_ui_map.values():
+                    idx = bubble_info['index']
+                    if idx < len(ui_history) and ui_history[idx][1]:
+                        # Remove the "Thinking..." indicator
+                        cleaned_md = ui_history[idx][1].replace("<br>🤔 Thinking...", "")
+                        # Collapse the details view for a cleaner final state
+                        cleaned_md = cleaned_md.replace("<details open>", "<details>")
+                        ui_history[idx][1] = cleaned_md
+
+                # Update the master LLM history state for the next turn
+                new_llm_history = llm_history + [
+                    {"role": "user", "content": message},
+                    full_assistant_message
+                ]
+
+                yield ui_history, gr.update(interactive=True), gr.update(interactive=True), new_llm_history
+
+            def on_reload_config(current_selected_agent: str):
+                print("\n--- Reloading AI Copilot Configuration ---")
+                copilot_service.reload()
+                new_agent_list = copilot_service.get_agent_list()
+                
+                # Preserve selection if possible, otherwise fall back to the first agent.
+                if current_selected_agent in new_agent_list:
+                    new_selected_agent = current_selected_agent
                 else:
-                    details_md = "No agents found after reload."
+                    new_selected_agent = new_agent_list[0] if new_agent_list else None
+
+                details_md = "No agents found after reload."
+                if new_selected_agent:
+                    agent_details = copilot_service.get_agent_details(new_selected_agent)
+                    if agent_details:
+                        details_md = f"**{agent_details.get('name', 'N/A')}**\n\n"
+                        details_md += f"*{agent_details.get('description', 'No description.')}*\n\n"
+                        
+                        if agent_details.get('model_prompt'):
+                            details_md += f"**System Prompt:**\n```\n{agent_details.get('model_prompt')}\n```\n"
+
+                        mcp_info = agent_details.get('mcp_info', None)
+                        tools = mcp_info.get('tools', []) if mcp_info else []
+                        if tools:
+                            details_md += "\n**Available Tools:**\n"
+                            for tool in tools:
+                                details_md += f"- `{tool.get('name')}`: {tool.get('description', 'No description.')}\n"
+                
+                new_html = generate_agent_list_html(copilot_service, new_selected_agent)
 
                 return (
-                    gr.update(choices=new_agent_list, value=new_selected_agent),
+                    new_selected_agent,
+                    new_html,
                     details_md,
-                    [] # Clear chatbot
+                    [], # Clear chatbot UI
+                    []  # Clear LLM history state
                 )
             
             # --- Wiring ---
             
-            # Agent selection logic
-            selected_agent_name.select(
-                on_select_agent,
-                inputs=[selected_agent_name],
-                outputs=[agent_details_display, chatbot]
+            # Agent selection from JS trigger
+            selected_agent_trigger.input(
+                fn=on_select_agent,
+                inputs=[selected_agent_trigger, selected_agent_name_state],
+                outputs=[
+                    agent_details_display,
+                    chatbot,
+                    conversation_history_state,
+                    selected_agent_name_state,
+                    agent_list_display
+                ],
+                queue=False
             )
 
             # Config reload logic
             reload_button.click(
                 on_reload_config,
-                inputs=[],
-                outputs=[selected_agent_name, agent_details_display, chatbot]
+                inputs=[selected_agent_name_state], # Pass the current state in
+                outputs=[
+                    selected_agent_name_state,
+                    agent_list_display,
+                    agent_details_display,
+                    chatbot,
+                    conversation_history_state
+                ],
+                js=_js_attach_listener # Re-attach listener after HTML is reloaded
             )
 
             # Chat logic
             chat_submit_event = chat_input.submit(
                 on_chat_message,
-                [selected_agent_name, chat_input, chatbot],
-                [chatbot, chat_input, send_button],
+                [selected_agent_name_state, chat_input, chatbot, conversation_history_state],
+                [chatbot, chat_input, send_button, conversation_history_state],
             ).then(
                 lambda: gr.update(value=""),
                 None,
@@ -129,8 +385,8 @@ def create_copilot_tab(state, copilot_service: CopilotService):
 
             send_button.click(
                 on_chat_message,
-                [selected_agent_name, chat_input, chatbot],
-                [chatbot, chat_input, send_button],
+                [selected_agent_name_state, chat_input, chatbot, conversation_history_state],
+                [chatbot, chat_input, send_button, conversation_history_state],
             ).then(
                 lambda: gr.update(value=""),
                 None,
@@ -138,10 +394,33 @@ def create_copilot_tab(state, copilot_service: CopilotService):
                 queue=False,
             )
             
-            # Initial load for agent details
+            # Initial load for agent details and list
             def initial_load_fn():
-                if agent_list:
-                    return on_select_agent(agent_list[0])[0]
-                return "No agents found."
-            
-            copilot_tab.select(initial_load_fn, None, agent_details_display)
+                initial_agent_name = agent_list[0] if agent_list else None
+                html = generate_agent_list_html(copilot_service, initial_agent_name)
+                
+                details_md = "Select an agent to see details."
+                if initial_agent_name:
+                    agent_details = copilot_service.get_agent_details(initial_agent_name)
+                    if agent_details:
+                        details_md = f"**{agent_details.get('name', 'N/A')}**\n\n"
+                        details_md += f"*{agent_details.get('description', 'No description.')}*\n\n"
+                        
+                        if agent_details.get('model_prompt'):
+                            details_md += f"**System Prompt:**\n```\n{agent_details.get('model_prompt')}\n```\n"
+
+                        mcp_info = agent_details.get('mcp_info', None)
+                        tools = mcp_info.get('tools', []) if mcp_info else []
+                        if tools:
+                            details_md += "\n**Available Tools:**\n"
+                            for tool in tools:
+                                details_md += f"- `{tool.get('name')}`: {tool.get('description', 'No description.')}\n"
+                
+                return html, details_md
+
+            copilot_tab.select(
+                initial_load_fn,
+                None,
+                [agent_list_display, agent_details_display],
+                js=_js_attach_listener # Attach listener when tab is first selected
+            )

--- a/ui/ui_copilot.py
+++ b/ui/ui_copilot.py
@@ -1,5 +1,147 @@
 import gradio as gr
+from core.copilot_service import CopilotService
+import json
 
-def create_copilot_tab(state):
-    with gr.TabItem("🤖 AI Copilot"):
-        gr.Markdown("## AI Copilot (to be implemented)") 
+def create_copilot_tab(state, copilot_service: CopilotService):
+    with gr.TabItem("🤖 AI Copilot") as copilot_tab:
+        with gr.Blocks(theme=gr.themes.Soft()):
+            with gr.Row(equal_height=False, elem_id="copilot-main-container"):
+                with gr.Column(scale=1, min_width=250):
+                    with gr.Row():
+                        gr.Markdown("### Agents")
+                        reload_button = gr.Button("🔄", variant="tool", elem_id="copilot-reload-button")
+
+                    agent_list = copilot_service.get_agent_list()
+                    
+                    selected_agent_name = gr.Radio(
+                        agent_list,
+                        label="Select Agent",
+                        value=agent_list[0] if agent_list else None,
+                        elem_id="copilot-agent-selector"
+                    )
+
+                    with gr.Accordion("Agent Details", open=True):
+                        agent_details_display = gr.Markdown("Select an agent to see details.", elem_id="agent-details-display")
+
+                with gr.Column(scale=3, elem_id="copilot-chat-column"):
+                    chatbot = gr.Chatbot(
+                        [],
+                        elem_id="copilot_chatbot",
+                        bubble_full_width=False,
+                        # height is now controlled by CSS for responsiveness
+                        label="Copilot Chat",
+                        show_copy_button=True
+                    )
+                    
+                    with gr.Row():
+                        chat_input = gr.Textbox(
+                            scale=4,
+                            show_label=False,
+                            placeholder="Ask the AI copilot anything...",
+                            container=False,
+                        )
+                        send_button = gr.Button("Send", scale=1, variant="primary")
+
+            # --- Event Handlers ---
+            def on_select_agent(agent_name):
+                agent_details = copilot_service.get_agent_details(agent_name)
+                if not agent_details:
+                    return "No details available.", []
+                
+                details_md = f"**{agent_details.get('name', 'N/A')}**\n\n"
+                details_md += f"*{agent_details.get('description', 'No description.')}*\n\n"
+                if agent_details.get('model_prompt', ""):
+                    details_md += f"**System Prompt:**\n```\n{agent_details.get('model_prompt')}\n```"
+                
+                return details_md, [] # returns details and clears chat history
+
+            def on_chat_message(agent_name, message, history):
+                if not message.strip():
+                    # Return updates for all outputs to avoid errors
+                    yield history, gr.update(), gr.update()
+                    return
+
+                history.append([message, None])
+                # Disable inputs during processing
+                yield history, gr.update(interactive=False), gr.update(interactive=False)
+                
+                if not agent_name:
+                    history[-1][1] = "Please select an agent first."
+                    # Re-enable inputs if no agent is selected
+                    yield history, gr.update(interactive=True), gr.update(interactive=True)
+                    return
+
+                user_message = history[-1][0]
+                service_history = [h for h in history[:-1] if h[1] is not None]
+                
+                # Stream the response
+                history[-1][1] = ""
+                response_generator = copilot_service.chat_with_agent(agent_name, user_message, service_history)
+                for token in response_generator:
+                    history[-1][1] += token
+                    yield history, gr.update(interactive=False), gr.update(interactive=False)
+
+                # Re-enable inputs after streaming is done
+                yield history, gr.update(interactive=True), gr.update(interactive=True)
+
+            def on_reload_config():
+                new_agent_list = copilot_service.reload()
+                new_selected_agent = new_agent_list[0] if new_agent_list else None
+                
+                if new_selected_agent:
+                    details_md, _ = on_select_agent(new_selected_agent)
+                else:
+                    details_md = "No agents found after reload."
+
+                return (
+                    gr.update(choices=new_agent_list, value=new_selected_agent),
+                    details_md,
+                    [] # Clear chatbot
+                )
+            
+            # --- Wiring ---
+            
+            # Agent selection logic
+            selected_agent_name.select(
+                on_select_agent,
+                inputs=[selected_agent_name],
+                outputs=[agent_details_display, chatbot]
+            )
+
+            # Config reload logic
+            reload_button.click(
+                on_reload_config,
+                inputs=[],
+                outputs=[selected_agent_name, agent_details_display, chatbot]
+            )
+
+            # Chat logic
+            chat_submit_event = chat_input.submit(
+                on_chat_message,
+                [selected_agent_name, chat_input, chatbot],
+                [chatbot, chat_input, send_button],
+            ).then(
+                lambda: gr.update(value=""),
+                None,
+                [chat_input],
+                queue=False,
+            )
+
+            send_button.click(
+                on_chat_message,
+                [selected_agent_name, chat_input, chatbot],
+                [chatbot, chat_input, send_button],
+            ).then(
+                lambda: gr.update(value=""),
+                None,
+                [chat_input],
+                queue=False,
+            )
+            
+            # Initial load for agent details
+            def initial_load_fn():
+                if agent_list:
+                    return on_select_agent(agent_list[0])[0]
+                return "No agents found."
+            
+            copilot_tab.select(initial_load_fn, None, agent_details_display)


### PR DESCRIPTION
This pull request implements the functionality for the "AI Copilot" tab, featuring a multi-agent chat interface with tool-use capabilities.

**Additions:**

*   **AI Copilot Interface:** The 'AI Copilot' tab is now functional, with a UI for agent selection and chat (`ui/ui_copilot.py`).
*   **Agent & Tool System:** Implemented a new `CopilotService` that manages agents and their tools. Tool execution is handled by `MCPServerManager`, which runs tools in separate processes.
    *   Includes three example agents: a "General Assistant" for basic chat, a "Calculator Assistant", and a "CSV Assistant" that can load and query CSV files from the local filesystem.

**How to Configure:**

1.  **Define a Custom Agent:**
    *   Create a JSON file in `core/copilot_agents/`.
    *   Specify the agent's `name`, `description`, `model_prompt`, and `mcp_info` for tools. See `calculator_assistant.json` and `csv_assistant.json` for examples.

2.  **Define a Tool Server:**
    *   Server scripts are located in `core/mcp_servers/`.
    *   The `calculator_server.py` and `csv_server.py` are reference implementations using `FastMCP`.

3.  **Configure LLM Provider:**
    *   Create a `.env` file in the project's root directory (use `algorithms/paper2code/env.sample` as a template).
    *   Set `DEFAULT_LLM_PROVIDER` to `gemini`, `openai`, or `anthropic` and add the corresponding API key.

---

> **Disclaimer**
>
> This functionality has only been tested for **Google Gemini**. Support for OpenAI and Anthropic is implemented but has not been verified.